### PR TITLE
Updated disabled check to allow for use of <a href="#">

### DIFF
--- a/sfsmallscreen.js
+++ b/sfsmallscreen.js
@@ -86,7 +86,7 @@
             classes += ' active';
           }
           // <option> has to be disabled if the item is not a link.
-          disable = item.is('span') ? ' disabled="disabled"' : '',
+          disable = item.is('span') || item.attr('href')=='#' ? ' disabled="disabled"' : '',
           // Crystal clear.
           subIndicator = 1 < level ? Array(level).join('-') + ' ' : '';
           // Preparing the <option> element.


### PR DESCRIPTION
Users of the drupal module special_menu_items find that its option of using <span> break the Superfish themeing.  Using <a href="#"> works except for smallscreen.js.  This update allows for both options.
