### PR TITLE
add "behaviour 3", which opens link on click, expands menu on arrow click

### DIFF
--- a/sftouchscreen.js
+++ b/sftouchscreen.js
@@ -47,8 +47,18 @@
         }
         // No .toggle() here as it's not possible to reset it.
         item.bind(eventHandler[0], function(event){
+          if (options.behaviour == 3){
+            if ($(event.target).is('.sf-sub-indicator')) {
+              event.preventDefault();
+              item.addClass('sf-clicked');
+              parent.showSuperfishUl().siblings('li:has(ul)').hideSuperfishUl().find('.sf-clicked').removeClass('sf-clicked');
+            }
+            else {
+              window.location = item.attr('href');
+            }
+          }
           // Already clicked?
-          if (item.hasClass('sf-clicked')){
+          else if (item.hasClass('sf-clicked')){
             // Depending on the preferred behaviour, either proceed to the URL.
             if (options.behaviour == 0){
               window.location = item.attr('href');


### PR DESCRIPTION
Great library -- thank you for your work! We wanted our tablet menus to open the link on click and expand the menu when the user clicks an arrow next to the link. I added this to the Drupal module as "behaviour 3", and will submit a patch to the module on drupal.org after I submit this.
https://www.drupal.org/node/2354373

Thanks again for your work. Everything works great -- I just thought this might be useful to other folks as well.
