### PR TITLE
Only hide the child ul-tag of the accordion and of the expanded li-tags.

### DIFF
--- a/sfsmallscreen.js
+++ b/sfsmallscreen.js
@@ -131,7 +131,7 @@
           // Removing style attributes and any unnecessary class.
           accordion.children('li').removeAttr('style').removeClass('sfHover');
           // Doing the same and making sure all the sub-menus are off-screen (hidden).
-          accordion.find('ul').removeAttr('style').not('.sf-hidden').addClass('sf-hidden');
+          accordion.children('ul').removeAttr('style').not('.sf-hidden').addClass('sf-hidden');
           // Creating the accordion toggle switch.
           var toggle = '<div class="sf-accordion-toggle ' + styleClass + '"><a href="#" id="' + toggleID + '"><span>' + options.title + '</span></a></div>';
 

--- a/sfsmallscreen.js
+++ b/sfsmallscreen.js
@@ -162,7 +162,7 @@
               // If the accordion is already expanded:
               // Hiding its expanded sub-menus and then the accordion itself as well.
               accordionElement.add(accordionElement.find('li.sf-expanded')).removeClass('sf-expanded')
-              .end().find('ul').hide()
+              .end().children('ul').hide()
               // This is a bit tricky, it's the same trick that has been in use in the main plugin for sometime.
               // Basically we'll add a class that keeps the sub-menu off-screen and still visible,
               // and make it invisible and removing the class one moment before showing or hiding it.


### PR DESCRIPTION
Using the drupal module menu_views and the accordion display the `<ul>` from the view get's hidden and class .sf-hidden added, but not activated again by clicking on its parent `<li>` item.
Superfish shouldn't hide all descendants `<ul>` tags, just the chil(dren) of an expanded li (the direct submenu) should be enough.
