### PR TITLE
Check if the browser was resized back to full width.

### DIFF
--- a/sftouchscreen.js
+++ b/sftouchscreen.js
@@ -50,7 +50,7 @@
           // Already clicked?
           if (item.hasClass('sf-clicked')){
             // Depending on the preferred behaviour, either proceed to the URL.
-            if (options.behaviour == 0){
+            if (options.behaviour == 0 || options.behaviour == 2 && mode == 'window_width' && windowWidth > breakpoint) {
               window.location = item.attr('href');
             }
             // or collapse the sub-menu.


### PR DESCRIPTION
Thanks for all your work on this awesome module!

I'm looking into an issue where the parent menu item link is disabled after the menu goes from hamburger to full. I'm using sf-touchscreen based on window width and adding cloned parent links options. 

I added an extra condition that checks if the browser went back to full menu.