### PR TITLE
Only hide the child ul-tag of the accordion.

### DIFF
--- a/sfsmallscreen.js
+++ b/sfsmallscreen.js
@@ -131,7 +131,7 @@
           // Removing style attributes and any unnecessary class.
           accordion.children('li').removeAttr('style').removeClass('sfHover');
           // Doing the same and making sure all the sub-menus are off-screen (hidden).
-          accordion.find('ul').removeAttr('style').not('.sf-hidden').addClass('sf-hidden');
+          accordion.children('ul').removeAttr('style').not('.sf-hidden').addClass('sf-hidden');
           // Creating the accordion toggle switch.
           var toggle = '<div class="sf-accordion-toggle ' + styleClass + '"><a href="#" id="' + toggleID + '"><span>' + options.title + '</span></a></div>';
 


### PR DESCRIPTION
Actually I am not sure if this is enough, because sub-submenus etc. should
be hidden also and their styles should be removed too. But this could be
done when a submenu get's opened.
Would be nice if a developer with more superfish experience could review
this issue.

Sea also pull request #14.