### PR TITLE
Uses stylesheet value for display: property when a menu is turned bac…

### DIFF
--- a/sfsmallscreen.js
+++ b/sfsmallscreen.js
@@ -269,8 +269,8 @@
       if (options.type == 'accordion'){
         $(id + '-toggle').parent('div').remove();
       }
-      // Crystal clear!
-      $(id).show();
+      // Remove inline CSS display property; less clear than simply using .show(), but respects stylesheet
+      $(id).css('display', '');
     }
 
     // Return original object to support chaining.


### PR DESCRIPTION
…k to a desktop menu after having been converted to a sfsmallscreen accordion menu.

See https://www.drupal.org/node/2559633 - when sfsmallscreen turns an accordion menu back into a desktop menu, jquery .show() adds a CSS display value of 'block'. To avoid this behavior, we can remove the display property instead of setting it with .show(). 

This makes the browser fall back on the stylesheet to determine the value for the CSS display property.