### PR TITLE
Arrows are truncated if the menu is set to a larger font.

### DIFF
--- a/css/superfish.css
+++ b/css/superfish.css
@@ -80,7 +80,7 @@ ul.sf-menu .sf-with-ul {
   padding-right: 3em;
 }
 ul.sf-menu .sf-sub-indicator {
-  height: 12px;
+  height: 1em;
   line-height: 9999px;
   opacity: 0.75;
   overflow: hidden;
@@ -94,7 +94,7 @@ ul.sf-menu .sf-sub-indicator {
   -ms-transform: translateY(-50%);
   -o-transform: translateY(-50%);
   transform: translateY(-50%);
-  width: 12px;
+  width: 1em;
 }
 ul.sf-menu .sf-sub-indicator:after {
   content: "▼";


### PR DESCRIPTION
  Use em rather than px to fix.