### PR TITLE
Don't clone parent menu item if it has no link

### DIFF
--- a/sfsmallscreen.js
+++ b/sfsmallscreen.js
@@ -188,10 +188,10 @@
               var parent = $(this).closest('li');
               // Creating and inserting Expand\Collapse buttons to the parent menu items,
               // of course only if not already happened.
-              if (options.accordionButton == 1 && parent.children('a.menuparent,span.nolink.menuparent').length > 0 && parent.children('ul').children('li.sf-clone-parent').length == 0){
+              if (options.accordionButton == 1 && parent.children('a[href].menuparent').length > 0 && parent.children('ul').children('li.sf-clone-parent').length == 0){
                 var
                 // Cloning the hyperlink of the parent menu item.
-                cloneLink = parent.children('a.menuparent,span.nolink.menuparent').clone(),
+                cloneLink = parent.children('a[href].menuparent').clone(),
                 // Wrapping the hyerplinks in <li>.
                 cloneLink = $('<li class="sf-clone-parent" />').html(cloneLink);
                 // Adding a helper class and attaching them to the sub-menus.

--- a/sftouchscreen.js
+++ b/sftouchscreen.js
@@ -33,10 +33,10 @@
           parent.unbind('mouseenter mouseleave');
         }
         if (options.behaviour == 2){
-          if (parent.children('a.menuparent,span.nolink.menuparent').length > 0 && parent.children('ul').children('.sf-clone-parent').length == 0){
+          if (parent.children('a[href].menuparent').length > 0 && parent.children('ul').children('.sf-clone-parent').length == 0){
             var
             // Cloning the hyperlink of the parent menu item.
-            cloneLink = parent.children('a.menuparent,span.nolink.menuparent').clone(),
+            cloneLink = parent.children('a[href].menuparent').clone(),
             // Wrapping the hyerplinks in <li>.
             cloneLink = $('<li class="sf-clone-parent" />').html(cloneLink);
             // Removing unnecessary stuff.


### PR DESCRIPTION
Showing a cloned menu item before its children in accordion view is
useless and confusing if the item has no link. This commit suppresses
such clones.

Menu items without links can be generated using the special_menu_items module.

Something similar should probably be applied to the 2.x branch too.

Thanks for considering it.
  