### PR TITLE
Closing the menu now properly hides all sub-menus.

### DIFF
--- a/sfsmallscreen.js
+++ b/sfsmallscreen.js
@@ -166,9 +166,9 @@
 
             if (accordionElement.hasClass('sf-expanded')){
               // If the accordion is already expanded:
-              // Hiding its expanded sub-menus and then the accordion itself as well.
+              // Hiding all expanded sub-menus and then the accordion itself as well.
               accordionElement.add(accordionElement.find('li.sf-expanded')).removeClass('sf-expanded')
-              .end().children('ul').hide()
+              .end().find('ul').hide().addClass('sf-hidden')
               // This is a bit tricky, it's the same trick that has been in use in the main plugin for some time.
               // Basically we'll add a class that keeps the sub-menu off-screen and still visible,
               // and make it invisible and removing the class one moment before showing or hiding it.


### PR DESCRIPTION
Hi.  There's a tiny bug with superfish on small screens: the .sf-hidden isn't getting applied to the children when it should.  If you open a submenu, then close and re-open the whole menu this can result in display errors.  Specifically, the submenu expands if you hover or long press.

Not a huge deal, but this should prevent that.