### PR TITLE
Update bind/unbind methods deprecated in newer versions of JQuery

### DIFF
--- a/sftouchscreen.js
+++ b/sftouchscreen.js
@@ -5,7 +5,7 @@
  * Built as a part of the Superfish project for Drupal (http://drupal.org/project/superfish)
  * Found any bug? have any cool ideas? contact me right away! http://drupal.org/user/619294/contact
  *
- * jQuery version: 1.3.x or higher.
+ * jQuery version: 1.7 or higher.
  *
  * Dual licensed under the MIT and GPL licenses:
  *  http://www.opensource.org/licenses/mit-license.php
@@ -30,7 +30,7 @@
         var item = $(this),
         parent = item.closest('li');
         if (options.disableHover){
-          parent.unbind('mouseenter mouseleave');
+          parent.off('mouseenter mouseleave');
         }
         if (options.behaviour == 2){
           if (parent.children('a.menuparent,span.nolink.menuparent').length > 0 && parent.children('ul').children('.sf-clone-parent').length == 0){
@@ -46,7 +46,7 @@
           }
         }
         // No .toggle() here as it's not possible to reset it.
-        item.bind(eventHandler[0], function(event){
+        item.on(eventHandler[0], function(event){
           // Already clicked?
           if (item.hasClass('sf-clicked')){
             // Depending on the preferred behaviour, either proceed to the URL.
@@ -72,7 +72,7 @@
         });
       });
 
-      $(document).bind(eventHandler[1], function(event){
+      $(document).on(eventHandler[1], function(event){
         if (menu.not(event.target) && menu.has(event.target).length === 0){
           menu.find('.sf-clicked').removeClass('sf-clicked');
           menu.find('li:has(ul)').hideSuperfishUl();


### PR DESCRIPTION
JQuery 1.3 is ancient and slow. Significant performance gains can be made by going to a newer version of JQuery, even with the compatibility layer in place.

Superfish is relying on methods that are available since JQuery 1.7, and deprecated in JQuery 3.0. If the JQuery compatibility layer is in place, these get reported in the dev console. Specifically bind() and unbind() are deprecated and easily 1:1 replaced with on() and off()

This PR updates the 2.X branch with the replacement methods. The hoverintent used in the 2.X branch already requires JQuery 1.9.1+, so this should be a straightforward addition without any dependency conflicts on older versions of JQuery.