### PR TITLE
Add Ipad detection for sf-touchscreen

### DIFF
--- a/sftouchscreen.js
+++ b/sftouchscreen.js
@@ -119,7 +119,11 @@
           }
         }
       }
-      else if (mode == 'useragent_predefined' && navigator.userAgent.match(/(android|bb\d+|meego)|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i)){
+      else if (
+        mode == 'useragent_predefined'
+        && navigator.userAgent.match(/(android|bb\d+|meego)|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od|ad)|iris|kindle|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i)
+        || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+      ){
         activate(menu);
       }
     }


### PR DESCRIPTION
This pull request adds Ipad to the user agent detection string for pre IOS13 devices and post IOS13 touch device detection based upon [this detection method](https://stackoverflow.com/a/57924983) using `navigator.maxTouchPoints`.