### PR TITLE
Address Core Web Vitals Accessibility issue - links do not have disce…

### DIFF
--- a/sfsmallscreen.js
+++ b/sfsmallscreen.js
@@ -138,7 +138,7 @@
           // Doing the same and making sure all the sub-menus are off-screen (hidden).
           accordion.children('ul').removeAttr('style').not('.sf-hidden').addClass('sf-hidden');
           // Creating the accordion toggle switch.
-          var toggle = '<div class="sf-accordion-toggle ' + styleClass + '"><a href="#" id="' + toggleID + '"><span>' + options.title + '</span></a></div>';
+          var toggle = '<div class="sf-accordion-toggle ' + styleClass + '"><a href="#" id="' + toggleID + '" aria-label="' + options.title + '"><span>' + options.title + '</span></a></div>';
 
           // Adding Expand\Collapse buttons if requested.
           if (options.accordionButton == 2){


### PR DESCRIPTION
Address Core Web Vitals Accessibility issue - links do not have discernible name.

When running Lighthouse or Page Speed Insights we see the following error when using Superfish for Drupal.
<img width="1091" alt="superfish-links-do-not-have-a-discernable-name" src="https://user-images.githubusercontent.com/21347123/143326374-a2fb92a4-f4ea-4086-a0bc-e2784d0e05f0.png">

I tested this solution and appears to resolve the accessibility issue.

aria-label
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute

SO discussion on this topic.
https://stackoverflow.com/questions/51683761/how-to-fix-lighthouse-links-do-not-have-a-discernible-name



